### PR TITLE
Update vantadye.augment

### DIFF
--- a/items/generic/dyes/vantadye.augment
+++ b/items/generic/dyes/vantadye.augment
@@ -3,7 +3,7 @@
   "price" : 25,
   "rarity" : "Common",
   "category" : "clothingDye",
-  "inventoryIcon" : "aegisaltdye.png",
+  "inventoryIcon" : "vantadye.png",
   "description" : "This coloured dye can be applied to a piece of armour or clothing with a right-click.",
   "shortdescription" : "Vantablack Dye",
 


### PR DESCRIPTION
fix for vanta dye to use the correct icon; was previously using the icon for aegisalt dye